### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Python CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pspvv/my-blog-practice/security/code-scanning/6](https://github.com/pspvv/my-blog-practice/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out the code), we will set `contents: read` as the minimal required permission. This change will ensure that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
